### PR TITLE
Add logic for making signals on-the-fly, sans p4p -vv call

### DIFF
--- a/src/ophyd_epics_devices/panda.py
+++ b/src/ophyd_epics_devices/panda.py
@@ -25,11 +25,11 @@ from ophyd.v2.core import (
     SimSignalBackend,
 )
 from ophyd.v2.epics import (
+    SignalR,
     epics_signal_r,
     epics_signal_rw,
     epics_signal_w,
     epics_signal_x,
-    SignalR,
 )
 from p4p.client.thread import Context
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,7 +54,7 @@ def pva():
             universal_newlines=True,
         )
         for macros in [
-            "INCLUDE_EXTRA_BLOCK=",
+            "INCLUDE_EXTRA_BLOCK=,INCLUDE_EXTRA_SIGNAL=",
             "EXCLUDE_WIDTH=#,IOC_NAME=PANDAQSRVIB",
             "EXCLUDE_PCAP=#,IOC_NAME=PANDAQSRVI",
         ]

--- a/tests/db/panda.db
+++ b/tests/db/panda.db
@@ -436,6 +436,19 @@ $(EXCLUDE_PCAP=)            }
 $(EXCLUDE_PCAP=)        }
 $(EXCLUDE_PCAP=)    })
 $(EXCLUDE_PCAP=)}
+
+$(INCLUDE_EXTRA_SIGNAL=#)record(ao, "$(IOC_NAME=PANDAQSRV):PCAP:ARM2")
+$(INCLUDE_EXTRA_SIGNAL=#){
+$(INCLUDE_EXTRA_SIGNAL=#)    info(Q:group, {
+$(INCLUDE_EXTRA_SIGNAL=#)        "$(IOC_NAME=PANDAQSRV):PCAP:PVI": {
+$(INCLUDE_EXTRA_SIGNAL=#)            "pvi.arm2.x": {
+$(INCLUDE_EXTRA_SIGNAL=#)                "+channel": "NAME",
+$(INCLUDE_EXTRA_SIGNAL=#)                "+type": "plain"
+$(INCLUDE_EXTRA_SIGNAL=#)            }
+$(INCLUDE_EXTRA_SIGNAL=#)        }
+$(INCLUDE_EXTRA_SIGNAL=#)    })
+$(INCLUDE_EXTRA_SIGNAL=#)}
+
 $(EXCLUDE_PCAP=)
 $(EXCLUDE_PCAP=)
 $(EXCLUDE_PCAP=)record(stringin, "$(IOC_NAME=PANDAQSRV):PCAP:_PVI")

--- a/tests/db/panda.db
+++ b/tests/db/panda.db
@@ -28,6 +28,21 @@ $(EXCLUDE_WIDTH=)        }
 $(EXCLUDE_WIDTH=)    })
 $(EXCLUDE_WIDTH=)}
 
+record(bi, "$(IOC_NAME=PANDAQSRV):PCAP:ACTIVE")
+{
+    field(ZNAM,  "0")
+    field(ONAM,  "1")
+    field(PINI, "YES")
+    info(Q:group, {
+        "$(IOC_NAME=PANDAQSRV):PCAP:PVI": {
+            "pvi.active.r": {
+                "+channel": "NAME",
+                "+type": "plain"
+            }
+        }
+    })
+}
+
 record(waveform, "BOOL:PLEASE")
 {
     field(NELM, 10)

--- a/tests/test_panda.py
+++ b/tests/test_panda.py
@@ -62,11 +62,12 @@ async def test_panda_with_missing_blocks(pva):
         await panda.connect()
 
 
-async def test_panda_with_extra_blocks(pva):
+async def test_panda_with_extra_blocks_and_signals(pva):
     panda = PandA("PANDAQSRV")
     await panda.connect()
 
     assert panda.extra, "extra device has not been instantiated"  # type: ignore
+    assert panda.pcap.arm2, "extra signal not instantiated"  # type: ignore
 
 
 async def test_panda_block_missing_signals(pva):


### PR DESCRIPTION
Resolves https://github.com/bluesky/ophyd-epics-devices/issues/25

For this to work, I need to be able to query the epics signal via pv access to get the type of the signal, to be used in the signal_factory (i.e epics_signal_ ... function). Two things need to happen for this to work:

1. The .db file being used (i.e. the one currently in tests/db/panda.db) needs to have enough information about the signal types,
2. I need a way of doing 'pvget -vv ${IOC:PV}' via python's p4p library. I am struggling to see how to do that.
edit: after discussion it seems like we can just use 'None' and the backend will guess.