### PR TITLE
Get real panda connected

### DIFF
--- a/docs/examples/panda_demo.py
+++ b/docs/examples/panda_demo.py
@@ -1,0 +1,14 @@
+from bluesky import RunEngine
+
+# these three lines just let you use await statements
+# #in ipython terminal with the Run Engine event loop.
+from IPython import get_ipython
+from ophyd.v2.core import DeviceCollector
+
+from ophyd_epics_devices.panda import PandA
+
+get_ipython().run_line_magic("autoawait", "call_in_bluesky_event_loop")
+RE = RunEngine()
+
+with DeviceCollector():
+    my_panda = PandA("TS-PANDA")

--- a/src/ophyd_epics_devices/utils.py
+++ b/src/ophyd_epics_devices/utils.py
@@ -1,0 +1,13 @@
+from typing import get_type_hints
+
+
+# Use with types, not instances
+def get_type_hints_no_inheritance(cls):
+    cls_hints = get_type_hints(cls)
+
+    for base_cls in cls.__bases__:
+        base_hints = get_type_hints(base_cls)
+        for base_hint_names in base_hints.keys():
+            if base_hint_names in cls_hints:
+                del cls_hints[base_hint_names]
+    return cls_hints

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,21 @@
+from typing import get_type_hints
+
+from ophyd_epics_devices.utils import get_type_hints_no_inheritance
+
+
+def test_get_type_hints_no_inheritance():
+    class BaseClass:
+        base_integer: int
+        base_string: str
+
+    class SubClass(BaseClass):
+        integer: int
+        string: str
+
+    assert get_type_hints(SubClass) == {
+        "base_integer": int,
+        "base_string": str,
+        "integer": int,
+        "string": str,
+    }
+    assert get_type_hints_no_inheritance(SubClass) == {"integer": int, "string": str}


### PR DESCRIPTION
Fixes the problems described in https://github.com/bluesky/ophyd-epics-devices/issues/34

To test, I ran a local PandABlocks IOC and managed to connect a real panda device with

```
async def test_set_panda_table():
    panda: PandA = PandA("WS103-PANDA")
    await panda.connect()
```

I'm not sure if the extra function `get_type_hints_no_inheritance` is the best fix so this is probably the main thing to look at in review