### PR TITLE
Make PandA DeviceVectors on the fly, allow broader regexp for blocks/signals

### DIFF
--- a/src/ophyd_epics_devices/panda.py
+++ b/src/ophyd_epics_devices/panda.py
@@ -252,9 +252,6 @@ class PandA(Device):
         """
         anno = get_type_hints(self).get(name)
 
-        # TODO this should not check specifically for pulse or seq block... just that
-        # it's a device vector.
-
         # if it's an annotated device vector, or it isn't but we've got a number then
         # make a DeviceVector on the class
         if get_origin(anno) == DeviceVector or (not anno and num is not None):
@@ -278,16 +275,16 @@ class PandA(Device):
             if not attr_name.startswith("_")
         }
 
-        # Remove 'fake' numbered blocks if non-numbered block is in PVI, e.g. if
-        #   both 'pcap' and 'pcap1' are in PVI, remove 'pcap1'.
-        pvi_keys = set(pvi.keys())
-        for k in pvi_keys:
-            kn = re.sub(r"\d*$", "", k)
-            if kn and k != kn and kn in pvi_keys:
-                del pvi[k]
-
         # create all the blocks pvi says it should have,
         if pvi:
+            # Remove 'fake' numbered blocks if non-numbered block is in PVI, e.g. if
+            # both 'pcap' and 'pcap1' are in PVI, remove 'pcap1'.
+            pvi_keys = set(pvi.keys())
+            for k in pvi_keys:
+                kn = re.sub(r"\d*$", "", k)
+                if kn and k != kn and kn in pvi_keys:
+                    del pvi[k]
+
             for block_name, block_pvi in pvi.items():
                 name, num = block_name_number(block_name)
 

--- a/src/ophyd_epics_devices/panda.py
+++ b/src/ophyd_epics_devices/panda.py
@@ -143,8 +143,8 @@ class PandA(Device):
     seq: DeviceVector[SeqBlock]
     pcap: PcapBlock
 
-    def __init__(self, prefix: str, name: str = "") -> None:
-        self._init_prefix = prefix
+    def __init__(self, pv: str) -> None:
+        self._init_prefix = pv
         self.pvi_mapping: Dict[FrozenSet[str], Callable[..., Signal]] = {
             frozenset({"r", "w"}): lambda dtype, rpv, wpv: epics_signal_rw(
                 dtype, rpv, wpv
@@ -323,5 +323,4 @@ class PandA(Device):
                 block = await self._make_block(block_name, num, "sim://", sim=sim)
                 self.set_attribute(block_name, num, block)
 
-        self.set_name(self.name)
         await super().connect(sim)

--- a/src/ophyd_epics_devices/panda.py
+++ b/src/ophyd_epics_devices/panda.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import atexit
 import re
 from enum import Enum
@@ -171,7 +173,7 @@ class PandA(Device):
 
     def verify_block(self, name: str, num: Optional[int]):
         """Given a block name and number, return information about a block."""
-        anno = get_type_hints(self).get(name)
+        anno = get_type_hints(self, globalns=globals()).get(name)
 
         block: Device = Device()
 
@@ -194,7 +196,7 @@ class PandA(Device):
         """
         block = self.verify_block(name, num)
 
-        field_annos = get_type_hints(block)
+        field_annos = get_type_hints(block, globalns=globals())
         block_pvi = await pvi_get(block_pv, self.ctxt) if not sim else None
 
         # finds which fields this class actually has, e.g. delay, width...
@@ -266,7 +268,7 @@ class PandA(Device):
         Need to be able to set device vectors on the panda as well, e.g. if num is not
         None, need to be able to make a new device vector and start populating it...
         """
-        anno = get_type_hints(self).get(name)
+        anno = get_type_hints(self, globalns=globals()).get(name)
 
         # if it's an annotated device vector, or it isn't but we've got a number then
         # make a DeviceVector on the class
@@ -287,7 +289,7 @@ class PandA(Device):
         pvi = await pvi_get(self._init_prefix + ":PVI", self.ctxt) if not sim else None
         hints = {
             attr_name: attr_type
-            for attr_name, attr_type in get_type_hints(self).items()
+            for attr_name, attr_type in get_type_hints(self, globalns=globals()).items()
             if not attr_name.startswith("_")
         }
 

--- a/src/ophyd_epics_devices/panda.py
+++ b/src/ophyd_epics_devices/panda.py
@@ -278,6 +278,14 @@ class PandA(Device):
             if not attr_name.startswith("_")
         }
 
+        # Remove 'fake' numbered blocks if non-numbered block is in PVI, e.g. if
+        #   both 'pcap' and 'pcap1' are in PVI, remove 'pcap1'.
+        pvi_keys = set(pvi.keys())
+        for k in pvi_keys:
+            kn = re.sub("\d*$", "", k)
+            if kn and k != kn and kn in pvi_keys:
+                del pvi[k]
+
         # create all the blocks pvi says it should have,
         if pvi:
             for block_name, block_pvi in pvi.items():

--- a/src/ophyd_epics_devices/panda.py
+++ b/src/ophyd_epics_devices/panda.py
@@ -323,4 +323,5 @@ class PandA(Device):
                 block = await self._make_block(block_name, num, "sim://", sim=sim)
                 self.set_attribute(block_name, num, block)
 
+        self.set_name(self.name)
         await super().connect(sim)

--- a/src/ophyd_epics_devices/panda.py
+++ b/src/ophyd_epics_devices/panda.py
@@ -282,7 +282,7 @@ class PandA(Device):
         #   both 'pcap' and 'pcap1' are in PVI, remove 'pcap1'.
         pvi_keys = set(pvi.keys())
         for k in pvi_keys:
-            kn = re.sub("\d*$", "", k)
+            kn = re.sub(r"\d*$", "", k)
             if kn and k != kn and kn in pvi_keys:
                 del pvi[k]
 

--- a/tests/db/panda.db
+++ b/tests/db/panda.db
@@ -480,10 +480,10 @@ $(EXCLUDE_PCAP=)    })
 $(EXCLUDE_PCAP=)}
 
 
-$(INCLUDE_EXTRA_BLOCK=#)record(ao, "$(IOC_NAME=PANDAQSRV):EXTRA:ARM")
+$(INCLUDE_EXTRA_BLOCK=#)record(ao, "$(IOC_NAME=PANDAQSRV):EXTRA1:ARM")
 $(INCLUDE_EXTRA_BLOCK=#){
 $(INCLUDE_EXTRA_BLOCK=#)    info(Q:group, {
-$(INCLUDE_EXTRA_BLOCK=#)        "$(IOC_NAME=PANDAQSRV):EXTRA:PVI": {
+$(INCLUDE_EXTRA_BLOCK=#)        "$(IOC_NAME=PANDAQSRV):EXTRA1:PVI": {
 $(INCLUDE_EXTRA_BLOCK=#)            "pvi.arm.x": {
 $(INCLUDE_EXTRA_BLOCK=#)                "+channel": "NAME",
 $(INCLUDE_EXTRA_BLOCK=#)                "+type": "plain"
@@ -493,12 +493,38 @@ $(INCLUDE_EXTRA_BLOCK=#)    })
 $(INCLUDE_EXTRA_BLOCK=#)}
 $(INCLUDE_EXTRA_BLOCK=#)
 $(INCLUDE_EXTRA_BLOCK=#)
-$(INCLUDE_EXTRA_BLOCK=#)record(stringin, "$(IOC_NAME=PANDAQSRV):EXTRA:_PVI")
+$(INCLUDE_EXTRA_BLOCK=#)record(stringin, "$(IOC_NAME=PANDAQSRV):EXTRA1:_PVI")
 $(INCLUDE_EXTRA_BLOCK=#){
-$(INCLUDE_EXTRA_BLOCK=#)    field(VAL,  "$(IOC_NAME=PANDAQSRV):EXTRA:PVI")
+$(INCLUDE_EXTRA_BLOCK=#)    field(VAL,  "$(IOC_NAME=PANDAQSRV):EXTRA1:PVI")
 $(INCLUDE_EXTRA_BLOCK=#)    info(Q:group, {
 $(INCLUDE_EXTRA_BLOCK=#)        "$(IOC_NAME=PANDAQSRV):PVI": {
-$(INCLUDE_EXTRA_BLOCK=#)            "pvi.extra.d": {
+$(INCLUDE_EXTRA_BLOCK=#)            "pvi.extra1.d": {
+$(INCLUDE_EXTRA_BLOCK=#)                "+channel": "VAL",
+$(INCLUDE_EXTRA_BLOCK=#)                "+type": "plain"
+$(INCLUDE_EXTRA_BLOCK=#)            }
+$(INCLUDE_EXTRA_BLOCK=#)        }
+$(INCLUDE_EXTRA_BLOCK=#)    })
+$(INCLUDE_EXTRA_BLOCK=#)}
+
+$(INCLUDE_EXTRA_BLOCK=#)record(ao, "$(IOC_NAME=PANDAQSRV):EXTRA2:ARM")
+$(INCLUDE_EXTRA_BLOCK=#){
+$(INCLUDE_EXTRA_BLOCK=#)    info(Q:group, {
+$(INCLUDE_EXTRA_BLOCK=#)        "$(IOC_NAME=PANDAQSRV):EXTRA2:PVI": {
+$(INCLUDE_EXTRA_BLOCK=#)            "pvi.arm.x": {
+$(INCLUDE_EXTRA_BLOCK=#)                "+channel": "NAME",
+$(INCLUDE_EXTRA_BLOCK=#)                "+type": "plain"
+$(INCLUDE_EXTRA_BLOCK=#)            }
+$(INCLUDE_EXTRA_BLOCK=#)        }
+$(INCLUDE_EXTRA_BLOCK=#)    })
+$(INCLUDE_EXTRA_BLOCK=#)}
+$(INCLUDE_EXTRA_BLOCK=#)
+$(INCLUDE_EXTRA_BLOCK=#)
+$(INCLUDE_EXTRA_BLOCK=#)record(stringin, "$(IOC_NAME=PANDAQSRV):EXTRA2:_PVI")
+$(INCLUDE_EXTRA_BLOCK=#){
+$(INCLUDE_EXTRA_BLOCK=#)    field(VAL,  "$(IOC_NAME=PANDAQSRV):EXTRA2:PVI")
+$(INCLUDE_EXTRA_BLOCK=#)    info(Q:group, {
+$(INCLUDE_EXTRA_BLOCK=#)        "$(IOC_NAME=PANDAQSRV):PVI": {
+$(INCLUDE_EXTRA_BLOCK=#)            "pvi.extra2.d": {
 $(INCLUDE_EXTRA_BLOCK=#)                "+channel": "VAL",
 $(INCLUDE_EXTRA_BLOCK=#)                "+type": "plain"
 $(INCLUDE_EXTRA_BLOCK=#)            }

--- a/tests/db/panda.db
+++ b/tests/db/panda.db
@@ -452,11 +452,11 @@ $(EXCLUDE_PCAP=)        }
 $(EXCLUDE_PCAP=)    })
 $(EXCLUDE_PCAP=)}
 
-$(INCLUDE_EXTRA_SIGNAL=#)record(ao, "$(IOC_NAME=PANDAQSRV):PCAP:ARM2")
+$(INCLUDE_EXTRA_SIGNAL=#)record(ao, "$(IOC_NAME=PANDAQSRV):PCAP:NEWSIGNAL")
 $(INCLUDE_EXTRA_SIGNAL=#){
 $(INCLUDE_EXTRA_SIGNAL=#)    info(Q:group, {
 $(INCLUDE_EXTRA_SIGNAL=#)        "$(IOC_NAME=PANDAQSRV):PCAP:PVI": {
-$(INCLUDE_EXTRA_SIGNAL=#)            "pvi.arm2.x": {
+$(INCLUDE_EXTRA_SIGNAL=#)            "pvi.newsignal.x": {
 $(INCLUDE_EXTRA_SIGNAL=#)                "+channel": "NAME",
 $(INCLUDE_EXTRA_SIGNAL=#)                "+type": "plain"
 $(INCLUDE_EXTRA_SIGNAL=#)            }

--- a/tests/test_panda.py
+++ b/tests/test_panda.py
@@ -66,8 +66,10 @@ async def test_panda_with_extra_blocks_and_signals(pva):
     panda = PandA("PANDAQSRV")
     await panda.connect()
 
-    assert panda.extra, "extra device has not been instantiated"  # type: ignore
-    assert panda.pcap.arm2, "extra signal not instantiated"  # type: ignore
+    assert panda.extra  # type: ignore
+    assert panda.extra[1]  # type: ignore
+    assert panda.extra[2]  # type: ignore
+    assert panda.pcap.arm2  # type: ignore
 
 
 async def test_panda_block_missing_signals(pva):


### PR DESCRIPTION
fixes https://github.com/bluesky/ophyd-epics-devices/issues/38

This will accept a broader range of regular expressions for the blocks, such that blocks that have a combinations of letters and numbers (and underscores/ -'s ) are allowed. The regexp only checks if there is a number at the very end, with the aim that any such number has the block instanted in a `DeviceVector` instance.

This will also allow the PandA to create DeviceVectors on the fly. Previously, if a pvi signal contained:

```
{
"someblock1": "MY_IOC:SOMEBLOCK1:...",
"someblock2": "MY_IOC:SOMEBLOCK2:...",
"someblock3": "MY_IOC:SOMEBLOCK3:...",
}
```

The PandA block after connection would contain `.someblock` as a Device, with the PV being set to the last one that was iterated through, i.e. `someblock1` and `someblock2` would be overwritten each time in the for loop where `_make_untyped_block` was being called. Now, `.someblock` is a DeviceVector, i.e. `.someblock[1]` would access `someblock1` and the index identifies which block is being accessed (just like for the typed device vectors).
