### PR TITLE
Add codecoverage settings with reasonable tolerance

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,10 +5,10 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 0.1%
+        threshold: 0.05%
     patch:
       default:
         target: auto
-        threshold: 0.1%
+        threshold: 0.05%
 github_checks:
   annotations: false

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,14 @@
+# show coverage in CI status, not as a comment.
+comment: false
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.1%
+    patch:
+      default:
+        target: auto
+        threshold: 0.1%
+github_checks:
+  annotations: false


### PR DESCRIPTION
Relates to https://github.com/bluesky/ophyd/issues/1149

As the repository grows it's going to get more and more annoying seeing CI fail because of a 0.01% patch change.

So this is just to introduce some reasonable tolerances. In ophyd's case it was 0.1%, here it should probably be less (as there are far fewer tests here)